### PR TITLE
Support multiple ice40 boards and chip types

### DIFF
--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -91,6 +91,7 @@ interface SimulationOptions {
 
 interface CodeGeneratorOptions {
   simulation?: SimulationOptions;
+  pcfPath?: string;
 };
 
 /**
@@ -189,7 +190,10 @@ export class CodeGenerator {
       await execP(yosysCommand);
       process.stdout.write(`Completed synthesis.\n`);
 
-      const constraintsFile = path.join(__dirname, '../../board-constraints/icebreaker.pcf');
+      const constraintsFile = this.options.pcfPath
+        ? path.join(process.cwd(), this.options.pcfPath)
+        : path.join(__dirname, '../../board-constraints/icebreaker.pcf');
+
       const nextpnrCommand = `nextpnr-ice40 --up5k --json ${projectName}.json --pcf ${constraintsFile} --asc ${projectName}.asc`;
       await execP(nextpnrCommand);
       process.stdout.write(`Completed place and route.\n`);

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -84,6 +84,21 @@ const execP = promisify(exec);
 /** @internal */
 const cleanupFiles = (filenames:string[]) => exec(`rm ${filenames.join(' ')}`);
 
+export enum DeviceTypes {
+  lp384 = 'lp384',
+  lp1k = 'lp1k',
+  lp4k = 'lp4k',
+  lp8k = 'lp8k',
+  hx1k = 'hx1k',
+  hx4k = 'hx4k',
+  hx8k = 'hx8k',
+  up3k = 'up3k',
+  up5k = 'up5k',
+  u1k = 'u1k',
+  u2k = 'u2k',
+  u4k = 'u4k',
+};
+
 interface SimulationOptions {
   enabled: boolean;
   timescale: TimeScaleValue[]
@@ -92,6 +107,7 @@ interface SimulationOptions {
 interface CodeGeneratorOptions {
   simulation?: SimulationOptions;
   pcfPath?: string;
+  deviceType?: DeviceTypes;
 };
 
 /**
@@ -194,7 +210,11 @@ export class CodeGenerator {
         ? path.join(process.cwd(), this.options.pcfPath)
         : path.join(__dirname, '../../board-constraints/icebreaker.pcf');
 
-      const nextpnrCommand = `nextpnr-ice40 --up5k --json ${projectName}.json --pcf ${constraintsFile} --asc ${projectName}.asc`;
+      const deviceTypeArgument = this.options.deviceType
+        ? `--${this.options.deviceType}`
+        : `--up5k`;
+
+      const nextpnrCommand = `nextpnr-ice40 ${deviceTypeArgument} --json ${projectName}.json --pcf ${constraintsFile} --asc ${projectName}.asc`;
       await execP(nextpnrCommand);
       process.stdout.write(`Completed place and route.\n`);
 


### PR DESCRIPTION
<!--

Thanks for taking an interest in this project, and the time to open a pull request!
Please use the following checklist to guide the process. If the checklist isn't able to fully convey your
intentions then feel free to leave elaboration comments below!

-->

## Support multiple ice40 boards and chip types

- [ ] This PR  only introduces changes to documentation.
  - Please include a summary of changes and an explanation
- [x] This PR adds new functionality
  - [x] Is there a related issue? (kind of)
    - Please note the related issue below, and how this PR relates to the issue if appropriate
  - [x] Does the code style reasonably match the existing code?
  - [ ] Are the changes tested?
- [ ] This PR introduces some other kind of change
  - Please explain the change below

This PR adds user configurability for both specifying a pcf constraint file, and the chip being used. In theory, this is the simpliest set of changes that allow boards other than the ice40 to work with gateware-ts.

In order to support the ECP5 and Xilinx boards that nextpnr can route for, this configuration will need to be expanded upon.