### PR TITLE
Add: Constraints around taking slices

### DIFF
--- a/src/signals.ts
+++ b/src/signals.ts
@@ -646,11 +646,24 @@ export class SliceT extends BaseSignalLike {
 
   constructor(a:SignalLike, fromBit:number, toBit:number) {
     super();
+
+    const smallest = Math.min(fromBit, toBit);
+    const largest = Math.max(fromBit, toBit);
+    const sliceWidth = largest - smallest + 1;
+
+    if (!Number.isInteger(sliceWidth)) {
+      throw new Error(`Slice width must be integer, but got ${sliceWidth}`);
+    }
+
+    if (sliceWidth > a.width) {
+      throw new Error(`Slice cannot have a larger width than the signal being sliced (slice=${sliceWidth}, signal=${a.width})`);
+    }
+
     // TODO: Assert logical stuff like bit ranges being valid
     this.a = a;
     this.fromBit = fromBit;
     this.toBit = toBit;
-    this.width = fromBit - toBit + 1;
+    this.width = sliceWidth;
   }
 
   clone():SliceT {


### PR DESCRIPTION
<!--

Thanks for taking an interest in this project, and the time to open a pull request!
Please use the following checklist to guide the process. If the checklist isn't able to fully convey your
intentions then feel free to leave elaboration comments below!

-->

## Constraints around taking slices
- [ ] This PR  only introduces changes to documentation.
  - Please include a summary of changes and an explanation
- [x] This PR adds new functionality
  - [x] Is there a related issue?
    - To close #41 
    - Please note the related issue below, and how this PR relates to the issue if appropriate
  - [x] Does the code style reasonably match the existing code?
  - [x] Are the changes tested?
- [ ] This PR introduces some other kind of change
  - Please explain the change below

This code introduces some constraints around taking slices of signals - explicitly allowing for LSB->MSB or MSB->LSB bit ordering, and erroring on bad inputs.